### PR TITLE
添加对服务端jar文件使用绝对路径的支持

### DIFF
--- a/core/Process/BaseMcserver.js
+++ b/core/Process/BaseMcserver.js
@@ -141,8 +141,12 @@ class ServerProcess extends EventEmitter {
 
         this._loading = true;
 
-        let jarPath = (this.dataModel.cwd + '/' + this.dataModel.jarName).replace(/\/\//igm, '/');
-
+        let jarPath = this.dataModel.jarName;
+        if (!path.isAbsolute(jarPath)) {
+            jarPath = (this.dataModel.cwd + '/' + this.dataModel.jarName)
+        }
+        jarPath = jarPath.replace(/\/\//igm, '/');
+        
         //选择启动方式 自定义命令与配置启动
         if (!this.dataModel.highCommande) {
             //只在非自定义模式下检查参数


### PR DESCRIPTION
今天在 Linux 上跑, 服务器文件夹没有放在这里面结果启动失败啦, 就加了个路径判断哦