### PR TITLE
在忽略极大体积数据的时候, 保留被截断消息的末尾部分

### DIFF
--- a/route/websocket/console.js
+++ b/route/websocket/console.js
@@ -108,9 +108,13 @@ setInterval(() => {
         if (!data || data.length <= 1) continue;
         //忽略极大体积数据
         const MAX_OUT_LEN = 1024 * (MCSERVER.localProperty.console_max_out || 28);
+        // 保留被截断消息的末尾部分
+        const KEEP_TAIL_LEN = 1024;
         if (data.length > MAX_OUT_LEN) {
+            let real_tail_len = Math.min(KEEP_TAIL_LEN, data.length - MAX_OUT_LEN);
             data = data.slice(0, MAX_OUT_LEN) +
-                "\n - 更多的此刻输出已经忽略...\n"
+                "\n - 更多的此刻输出已经忽略...\n" +
+                data.slice(data.length - real_tail_len, data.length);
         }
         // 替换元素
         let htmlData = data.replace(/\n/gim, '<br />');


### PR DESCRIPTION
今天在开服删减mod的时候发现, 如果触发  /fml confirm 确认, 通常显示不出来 (被忽略大体积数据吞了)
这样服主会不知道为什么服务器没动静了.
其实在等待输入 /fml confirm

钟鼓馔玉不足贵，但愿长醉不复醒。

```

[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:anvil
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:red_cushion_chair
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:ruby_block
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:washing_machine
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:wooden_flooring
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:mechanical_anvil
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:red_rug
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:berrytree_charti
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:red_folding_chair
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:silicon_ore
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:cyan_water_float
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:sun_stone_ore
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:green_rug
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:timed_fall
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:orange_clock
[  13:29:00  ] [ Server thread/INFO ] [ FML ]: Registry Block: Found a missing id from the world pixelmon:red_apricorn_tree
[  13:29:00  ] [ Server thread/INFO ] [ FM
 - 更多的此刻输出已经忽略...

(以下是修改后会新增的尾部输出)
n.mob.bellsprout
    pixelmon:pixelmon.mob.chinchou
    pixelmon:pixelmon.mob.prinplup
    pixelmon:pixelmon.mob.weavile
    pixelmon:pixelmon.mob.rayquaza
    pixelmon:pixelmon.mob.gible
    pixelmon:pixelmon.mob.slaking
    pixelmon:pixelmon.mob.aron
    pixelmon:pixelmon.mob.gabite
    pixelmon:pixelmon.mob.doduo
    pixelmon:pixelmon.mob.farfetchd
    pixelmon:pixelmon.mob.gligar
    pixelmon:pixelmon.mob.kricketune
    pixelmon:pixelmon.mob.latias
    pixelmon:pixelmon.mob.chingling
    pixelmon:pixelmon.mob.dodrio
    pixelmon:pixelmon.mob.starly


Run the command /fml confirm or or /fml cancel to proceed.
Alternatively start the server with -Dfml.queryResult=confirm or -Dfml.queryResult=cancel to preselect the answer.
[  13:29:00  ] [ Forge Version Check/INFO ] [ forge.VersionCheck ]: [ spongeforge ] Found status: OUTDATED Target: 7.1.2
[  13:29:00  ] [ Forge Version Check/INFO ] [ forge.VersionCheck ]: [ forge ] Starting version check at http://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json
[  13:29:04  ] [ Forge Version Check/INFO ] [ forge.VersionCheck ]: [ forge ] Found status: UP_TO_DATE Target: null
[ SYSTEM ] MCSM Console... 
```