### PR TITLE
FIX: cross-device rename

### DIFF
--- a/onlinefs/controller/function.js
+++ b/onlinefs/controller/function.js
@@ -157,7 +157,7 @@ router.post("/upload", upload.single("upload_file"), (req, res) => {
   if (req.file) {
     const originalname = req.file.originalname;
     const dstPath = pathm.join(target_path, originalname);
-    fs.rename(req.file.path, dstPath, (err) => {
+    fs.move(req.file.path, dstPath, (err) => {
       if (err) {
         res.status(500).send("上传虽然成功，但是处理文件出错: " + err);
       } else {


### PR DESCRIPTION
FIX for `Error: EXDEV: cross-device link not permitted` #356

Using `fs.move` to check cross-device first

https://github.com/jprichardson/node-fs-extra/blob/6bffcd81881ae474d3d1765be7dd389b5edfd0e0/lib/move/move.js#L11
