### PR TITLE
修改 支持Docker多端口映射

### DIFF
--- a/core/Process/BaseMcserver.js
+++ b/core/Process/BaseMcserver.js
@@ -91,34 +91,37 @@ class ServerProcess extends EventEmitter {
     const startCommandeArray = startCommande.split(" ");
     let portmap = this.dataModel.dockerConfig.dockerPorts;
     // 端口解析
-    var agreement = portmap.split("/");
-    var protocol = "tcp";
-    if (agreement.length >= 2 && (agreement[1] === "udp" || agreement[1] === "tcp")) {
-      protocol = agreement[1];
-    }
-    portmap = portmap.split(":");
-    if (portmap.length > 2) {
-      throw new Error("不支持的多端口操作方法，参数配置端口数量错误。");
-    }
+    var ports = portmap.split("|");
     // 绑定内部暴露端口
     const ExposedPortsObj = {};
     // 绑定内部暴露端口与其对应的宿主机端口
     const PortBindingsObj = {};
-    if (portmap.length == 2) {
-      // 一个端口的配置项目
-      ExposedPortsObj[portmap[0] + "/" + protocol] = {};
-      PortBindingsObj[portmap[0] + "/" + protocol] = [
-        {
-          HostPort: portmap[1] + ""
-        }
-      ];
+    for (var portstr of ports) {
+      var agreement = portstr.split("/");
+      var protocol = "tcp";
+      if (agreement.length >= 2 && (agreement[1] === "udp" || agreement[1] === "tcp")) {
+        protocol = agreement[1];
+      }
+      var port = portstr.split(":");
+      if (port.length > 2) {
+        throw new Error("参数配置端口映射错误。");
+      }
+      if (port.length == 2) {
+        // 一个端口的配置项目
+        ExposedPortsObj[port[0] + "/" + protocol] = {};
+        PortBindingsObj[port[0] + "/" + protocol] = [
+          {
+            HostPort: port[1] + ""
+          }
+        ];
+      }
     }
     // 输出启动消息
     MCSERVER.log("实例 [", this.dataModel.name, "] 正在启动...");
     MCSERVER.log("-------------------------------");
     MCSERVER.log("正在使用虚拟化技术启动进程");
     MCSERVER.log("命令:", startCommandeArray.join(" "));
-    MCSERVER.log("开放端口:", portmap.join("->"));
+    MCSERVER.log("开放端口:", portmap);
     MCSERVER.log("工作目录:", stdCwd);
     MCSERVER.log("-------------------------------");
 

--- a/public/template/dialog/docker_config.html
+++ b/public/template/dialog/docker_config.html
@@ -27,15 +27,15 @@
   </p>
   <div class="input-group input-group-sm">
     <span class="input-group-addon" id="sizing-addon3">内存限制</span>
-    <input type="text" class="form-control" placeholder="可填，列如填写 2G 则代表容器最大可使用 2G 内存。" aria-describedby="sizing-addon3" v-model="dockerXmx" />
+    <input type="text" class="form-control" placeholder="可填，例如填写 2G 则代表容器最大可使用 2G 内存。" aria-describedby="sizing-addon3" v-model="dockerXmx" />
   </div>
   <p>
     <small>开放的端口,冒号左边代表容器内部端口,右边代表宿主机端口,通常保持相同即可。</small>
   </p>
-  <p><small>目前最多只准许开放一个</small></p>
+  <p><small>如果任意一个端口被占用，服务器将会无法启动。多个端口用 | 分割。</small></p>
   <div class="input-group input-group-sm">
     <span class="input-group-addon" id="sizing-addon3">开放端口</span>
-    <input type="text" class="form-control" placeholder="可填，列如 25565:25565" aria-describedby="sizing-addon3" v-model="dockerPorts" />
+    <input type="text" class="form-control" placeholder="可填，例如 25565:25565/tcp|25565:25565/udp|8080:8080/tcp" aria-describedby="sizing-addon3" v-model="dockerPorts" />
   </div>
   <p>
     确认无误之后，单击保存即可 | &nbsp;


### PR DESCRIPTION
添加了对于docker启动的多端口支持
我提供的示例配置可以同时监听UDP和TCP端口，以及类似于旅行地图mod的网页地图功能所需要的端口